### PR TITLE
support webpack v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wcer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": false,
   "description": "Watch for changes and force the reload of the chrome extension",
   "main": "build/index.js",

--- a/src/ReloadPlugin.ts
+++ b/src/ReloadPlugin.ts
@@ -100,7 +100,12 @@ export default class ReloadPlugin extends AbstractPlugin {
   }
   generate(comp, done) {
     if(!this.manifest) return done()
-    comp.fileDependencies.push(this.manifestPath)
+    const {fileDependencies} = comp;
+    if (fileDependencies instanceof Set) {
+      fileDependencies.add(this.manifestPath)
+    } else {
+      fileDependencies.push(this.manifestPath)
+    }
     let source = JSON.stringify(this.manifest)
     comp.assets['manifest.json'] = {
       source: () => source,


### PR DESCRIPTION
In webpack 4, `compiler.fileDependencies` is an instance of SortableSet, which inherit from `Set`. So, when I use this plugin in webpack 4, I got a 'TypeError: comp.fileDependencies.push is not a function'.
I fixed it by determining `fileDependencies`'s type, if it is a SortableSet, use `.add` to add manifestPath, otherwise keep using `.push`.